### PR TITLE
Update syntax for install_sources:

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The charm may provide defaults for these service configuration
   the | character indicates that the value is a multiline string):
 
   ```yaml
-  install_sources: |
+  install_sources:
+      default: |
       - ppa:stub/cassandra
       - deb http://www.apache.org/dist/cassandra/debian 21x main
   ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The charm may provide defaults for these service configuration
   a string:
 
   ```yaml
-  install_keys: |
+  install_keys:
+      default: |
       - null
       - |
           -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
I had to add a 'default' subkey to install_sources in order for charm build to not choke on it.